### PR TITLE
Fix connection error via LAN. Note:

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "webpack.config.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "NODE_ENV=development webpack-dev-server --mode development --open",
+    "start": "NODE_ENV=development webpack-dev-server --mode development --open --host 0.0.0.0",
     "dev": "NODE_ENV=development webpack --mode development",
     "build": "NODE_ENV=production webpack --mode production",
     "clean": "rm -rf docs"


### PR DESCRIPTION
Example: Access `192.168.1.101:8080` in mobile phone.

---

It can be removed in latest webpack.
However, too many error to fix.
Before that, should migrate to @babel/core and @babel/preset-env first.